### PR TITLE
Server live reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 npm-debug.log
 .env
 .idea
+server/log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,8 @@ var connect = require('gulp-connect'),
     wiredep = require('wiredep').stream,
     htmlify = require('gulp-angular-htmlify'),
     ngAnnotate = require('gulp-ng-annotate'),
-    run = require('gulp-run');
+    nodemon = require('gulp-nodemon'),
+    shell = require('gulp-shell');
 
 gulp.task('lint', function() {
   return gulp.src(['./server/**/*.js','./client/app/**/*.js'])
@@ -114,39 +115,29 @@ gulp.task('frontend',['serve:frontend'], function() {
 });
 
 
-/**** Testing gulp-nodemon ****/
-var nodemon = require('gulp-nodemon');
-gulp.task('watch', function() {
-  gulp.watch(['./server/**/*.js', '!./server/test/**/*.js']);
-});
-
-gulp.task('demon', function() {
+/* Serve the server. gulp-nodemon is used for automatic
+ * restarting upon changes to *.js files, excluding tests.
+ * Note: do not start directories with ./ in watch and ignore
+ */
+gulp.task('backend', function() {
   nodemon({
-    script: './server/app.js',
-    ext: 'js',
-    ignore: ['./server/test/**/*.js']
+    script: 'server/app.js',
+    watch: ['server/**/*.js'],
+    ignore: ['server/test/**/*.js']
   })
-    .on('start', ['watch'])
-    .on('change', ['watch'])
     .on('restart', function() {
-      consol.log('Restarted.');
+      console.log('Server restarting. Please wait.');
     });
 });
-/**** end gulp-nodemon test ****/
 
-
-
-/* Serve the server using node foreman */
-gulp.task('serve:backend', function () {
-  run('nf start web').exec()
-    .pipe(gulp.dest('./server/log'));
+/* Use foreman to serve the server, allowing gulp-nodemon
+ * to automatically access the .env file.
+ */
+gulp.task('serve:backend', function() {
+  return gulp.src('')
+    .pipe(shell('nf run gulp backend'))
 });
 
-/* Watch server files for change */
-gulp.task('backend', ['serve:backend'], function() {
-  gulp.watch(['./server/**/*.js',
-              '!./server/test/**/*.js'], ['serve:backend']);
-});
 
 /* This will run our mocha tests */
 gulp.task('test', function() {
@@ -156,7 +147,7 @@ gulp.task('test', function() {
 });
 
 /* This will create the dist folder
- * That is ready to serve by our backend
+ * that is ready to serve by our backend
  */
 gulp.task('dist', [
     'lint',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,7 +66,7 @@ gulp.task('copy:assets', function () {
 });
 
 /* This will create concatenate all our angular
- * code into one file the bundle.js and palce it
+ * code into one file the bundle.js and place it
  * in the dist folder
  */
 gulp.task('concat', function() {
@@ -113,6 +113,29 @@ gulp.task('frontend',['serve:frontend'], function() {
   gulp.watch('./client/assets/**', ['copy:assets']);
 });
 
+
+/**** Testing gulp-nodemon ****/
+var nodemon = require('gulp-nodemon');
+gulp.task('watch', function() {
+  gulp.watch(['./server/**/*.js', '!./server/test/**/*.js']);
+});
+
+gulp.task('demon', function() {
+  nodemon({
+    script: './server/app.js',
+    ext: 'js',
+    ignore: ['./server/test/**/*.js']
+  })
+    .on('start', ['watch'])
+    .on('change', ['watch'])
+    .on('restart', function() {
+      consol.log('Restarted.');
+    });
+});
+/**** end gulp-nodemon test ****/
+
+
+
 /* Serve the server using node foreman */
 gulp.task('serve:backend', function () {
   run('nf start web').exec()
@@ -126,7 +149,7 @@ gulp.task('backend', ['serve:backend'], function() {
 });
 
 /* This will run our mocha tests */
-gulp.task('test', function(){
+gulp.task('test', function() {
    return gulp.src('./server/test/*.js', {read: false})
     .pipe(mocha({reporter: 'spec'}))
     .pipe(exit());
@@ -151,4 +174,4 @@ gulp.task('build:dev', ['dist']);
 gulp.task('build:prod', ['minify:js', 'minify:css', 'htmlify']);
 
 /* The default task */
-gulp.task('default', ['build:dev']);
+gulp.task('default', ['demon']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -174,4 +174,4 @@ gulp.task('build:dev', ['dist']);
 gulp.task('build:prod', ['minify:js', 'minify:css', 'htmlify']);
 
 /* The default task */
-gulp.task('default', ['demon']);
+gulp.task('default', ['build:dev']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,8 @@ var connect = require('gulp-connect'),
     exit = require('gulp-exit'),
     wiredep = require('wiredep').stream,
     htmlify = require('gulp-angular-htmlify'),
-    ngAnnotate = require('gulp-ng-annotate');
+    ngAnnotate = require('gulp-ng-annotate'),
+    run = require('gulp-run');
 
 gulp.task('lint', function() {
   return gulp.src(['./server/**/*.js','./client/app/**/*.js'])
@@ -110,6 +111,18 @@ gulp.task('frontend',['serve:frontend'], function() {
   gulp.watch('./client/bower_components', ['copy:bower-components', 'bower']);
   gulp.watch(['./client/index.html', './client/app/**/*'], ['concat', 'copy:views', 'bower']);
   gulp.watch('./client/assets/**', ['copy:assets']);
+});
+
+/* Serve the server using node foreman */
+gulp.task('serve:backend', function () {
+  run('nf start web').exec()
+    .pipe(gulp.dest('./server/log'));
+});
+
+/* Watch server files for change */
+gulp.task('backend', ['serve:backend'], function() {
+  gulp.watch(['./server/**/*.js',
+              '!./server/test/**/*.js'], ['serve:backend']);
 });
 
 /* This will run our mocha tests */

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "gulp-minify-css": "0.4.5",
     "gulp-mocha": "2.0.0",
     "gulp-ng-annotate": "0.5.2",
+    "gulp-nodemon": "1.0.5",
+    "gulp-shell": "0.3.0",
     "gulp-uglify": "1.1.0",
     "jwt-simple": "0.2.0",
     "mongoose": "3.8.21",
@@ -43,7 +45,6 @@
   },
   "devDependencies": {
     "chai": "1.10.0",
-    "gulp-run": "^1.6.6",
     "mocha": "2.1.0",
     "supertest": "0.15.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "chai": "1.10.0",
+    "gulp-run": "^1.6.6",
     "mocha": "2.1.0",
     "supertest": "0.15.0"
   },


### PR DESCRIPTION
Build team task of implementing server livereload. Uses gulp-nodemon to watch for file change and also restarts server accordingly. Normally nodemon requires the user to hardcode environment variables manually, but since we're using foreman (and to maintain privacy of environment variables), another task was created to indirectly provide the environment variables to nodemon when it starts/restarts the server.
